### PR TITLE
Add placeholder modal for svg to mods feature

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -15,6 +15,7 @@ import { inputRenderers } from "./views/inputRenderers.js";
 import { initCodeMirror } from "./codemirror/codemirror.js";
 import { drawDownloadGerberModal } from "./views/drawDownloadGerberModal.js";
 import { drawDownloadKiCadModal } from "./views/drawDownloadKiCadModal.js";
+import { drawSvgToModsModal } from "./views/drawSvgToModsModal.js";
 import "./components/netlist-editor.js";
 import "./components/wire-editor.js";
 import "./components/color-picker.js";
@@ -99,6 +100,7 @@ export function view(state) {
 		</div>
 		${drawDownloadGerberModal(state)}
 		${drawDownloadKiCadModal(state)}
+		${drawSvgToModsModal(state)}
 		<netlist-editor .pcb=${state.pcb} .idToName=${state.idToName}></netlist-editor>
 	`
 }
@@ -141,6 +143,13 @@ const menu = state => html`
 							dispatch("RENDER");
 						}}>
 						kicad
+					</div>
+					<div class="menu-item"
+						@click=${(e) => {
+							state.svgToModsModal = true;
+							dispatch("RENDER");
+						}}>
+						mods
 					</div>
 					<input 
 						class="input-item"

--- a/js/views/drawSvgToModsModal.js
+++ b/js/views/drawSvgToModsModal.js
@@ -1,0 +1,74 @@
+/*
+This feature sends board svg from SvgPcb to Mods via WebSockets.
+
+There could be two ways or two directions to do it.
+
+1. From SvgPcb to Mods
+---
+It would fire up Mods and send the SVG file to it with one click.
+No need to sync between SvgPcb and Mods manually. No need to enter
+web sockets addresses ports etc.
+
+2. 
+---
+Pull from Mods, where a Mods module would have fields for IP address
+and port + a button that pulls the active board design from SvgPcb.
+
+
+*/
+
+import { html } from "lit-html";
+//import { downloadGerber, GerberDrillFormat } from "../events/downloadGerber.js";
+import { dispatch } from "../dispatch.js";
+
+export const drawSvgToModsModal = state => {
+    if (!state.svgToModsModal) return "";
+
+    return html`
+    <div id="modal_svg_to_mods" class="modal">
+    	<div class="modal-content">
+    		<div class="modal-header">
+    			<div class="col-75 align-left">
+    				<i class="icon fa fa-arrow-circle-down"></i>
+    				<h3 class="modal-title">SVG to Mods Options</h3>
+    			</div>
+    			<div class="col-25 align-right">
+    				<span 
+    					class="close"
+    					@click=${(e) => {
+    						const modal = document.getElementById("modal_svg_to_mods");
+    						state.svgToModsModal = false;
+    						dispatch("RENDER");
+    					}}><i class="fa fa-times"></i></span>
+    			</div>
+    		</div>
+    		<div class="modal-body">
+    			<div class="col-50">
+    				<h4>Some options maybe</h4>
+    				<p>...</p>
+    			</div> <!-- /.col-50 -->
+    		</div> <!-- /.modal-body -->
+    		<div class="modal-footer">
+    			<button 
+    				type="button" 
+    				class="btn"
+    				@click=${(e) => {
+    					state.svgToModsModal = false;
+    					dispatch("RENDER");
+    				}}>Cancel</button>
+    			<button 
+    				type="button" 
+    				class="btn btn-primary"
+    				@click=${(e) => {
+    					state.svgToModsModal = false;
+
+    					// This will call the actual implementation of the thing
+    					//doSvgToModsThing(state);
+    					
+    					dispatch("RENDER");
+    				}}>Push to Mods</button>
+    		</div>
+    	</div>
+    </div>
+    `;
+}


### PR DESCRIPTION
At the Spain bootcamp this year a need to have a SvgPcb <> Mods connection was identified. We created this pull request with [John](https://fabacademy.org/2021/labs/plusx/students/john-story/about/) to work on it.

Essentially we want two things.

1. The possibility to push svg to Mods milling flow with one click. SvgPcb would spawn Mods and send over SVG of the current board.
2. From Mods, pull in active design from an open instance of SvgPcb. 

Let's do it!