### PR TITLE
Copy images to dist on deploy

### DIFF
--- a/copyAssets.sh
+++ b/copyAssets.sh
@@ -1,3 +1,4 @@
 cp -r components dist
 cp -r examples dist
+cp -r images dist
 cp styles.css dist


### PR DESCRIPTION
Did not notice that there is the `copyAssets.sh` script that copies a variety of folders to 'dist' for web. The gif with Neil was in images folder which is not copied over automatically. Now it should be.